### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/rendertables.php
+++ b/syntax/rendertables.php
@@ -45,7 +45,7 @@ class syntax_plugin_ipmap_rendertables extends DokuWiki_Syntax_Plugin
 		$this->Lexer->addExitPattern('</ipmap>','plugin_ipmap_rendertables');
 	}
 
-	function handle($match, $state, $pos, &$handler)
+	function handle($match, $state, $pos, Doku_Handler $handler)
 	{
 		//This function should eventually do all the parsing of the incoming data, to save time (it can be cached).
 		
@@ -70,7 +70,7 @@ class syntax_plugin_ipmap_rendertables extends DokuWiki_Syntax_Plugin
 		}
 	}
 	
-	function render($mode, &$renderer, $data)
+	function render($mode, Doku_Renderer $renderer, $data)
 	{
 		//Choose the output mode. XHTML is the most common.
 		switch($mode)


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
